### PR TITLE
[TC-94]-api/v1/tourInfoOpenApi/keyword 페이징 처리 적용

### DIFF
--- a/src/main/java/com/server/booyoungee/domain/place/api/tour/TourInfoOpenApiController.java
+++ b/src/main/java/com/server/booyoungee/domain/place/api/tour/TourInfoOpenApiController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.server.booyoungee.domain.place.application.tour.TourInfoOpenApiService;
 import com.server.booyoungee.domain.place.application.tour.TourPlaceService;
 import com.server.booyoungee.domain.place.dto.response.PlaceSummaryListResponse;
+import com.server.booyoungee.domain.place.dto.response.PlaceSummaryPageResponse;
 import com.server.booyoungee.domain.place.dto.response.tour.TourInfoAreaResponseDto;
 import com.server.booyoungee.domain.place.dto.response.tour.TourInfoCommonResponse;
 import com.server.booyoungee.domain.place.dto.response.tour.TourInfoDetailsResponseDto;
@@ -75,7 +77,7 @@ public class TourInfoOpenApiController {
 		@ApiResponse(
 			responseCode = "200",
 			description = "키워드 기반 관광 정보 검색 성공",
-			content = @Content(schema = @Schema(implementation = PlaceSummaryListResponse.class))
+			content = @Content(schema = @Schema(implementation = PlaceSummaryPageResponse.class))
 		),
 		@ApiResponse(
 			responseCode = "400",
@@ -84,7 +86,7 @@ public class TourInfoOpenApiController {
 		),
 	})
 	@GetMapping("/keyword")
-	public ResponseModel<PlaceSummaryListResponse> getOpenApiInfoByKeyword(
+	public ResponseModel<PlaceSummaryPageResponse> getOpenApiInfoByKeyword(
 		@Parameter(description = "페이지 내 최대 응답 개수", example = "10", required = true) @RequestParam @Positive int numOfRows,
 		@Parameter(description = "페이지 인덱스", example = "0", required = true) @RequestParam @PositiveOrZero int pageNo,
 		@Parameter(description = "검색 키워드", example = "해운대", required = true) @RequestParam String keyword
@@ -93,7 +95,7 @@ public class TourInfoOpenApiController {
 			.getTourInfoByKeyword(numOfRows, pageNo, keyword);
 		tourPlaceService.viewContents(jsonResult);
 
-		PlaceSummaryListResponse response = tourPlaceService.getPlaceByKeyword(jsonResult);
+		PlaceSummaryPageResponse response = tourPlaceService.getPlaceByKeyword(jsonResult, PageRequest.of(pageNo, numOfRows));
 		return response.contents().isEmpty()
 			? ResponseModel.success(NO_CONTENT, response)
 			: ResponseModel.success(response);

--- a/src/main/java/com/server/booyoungee/domain/place/application/tour/TourPlaceService.java
+++ b/src/main/java/com/server/booyoungee/domain/place/application/tour/TourPlaceService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import com.server.booyoungee.domain.place.domain.PlaceType;
 import com.server.booyoungee.domain.place.domain.tour.TourContentType;
 import com.server.booyoungee.domain.place.domain.tour.TourPlace;
 import com.server.booyoungee.domain.place.dto.response.PlaceSummaryListResponse;
+import com.server.booyoungee.domain.place.dto.response.PlaceSummaryPageResponse;
 import com.server.booyoungee.domain.place.dto.response.PlaceSummaryResponse;
 import com.server.booyoungee.domain.place.dto.response.tour.TourInfoCommonResponse;
 import com.server.booyoungee.domain.place.dto.response.tour.TourInfoDetailsResponseDto;
@@ -25,6 +27,7 @@ import com.server.booyoungee.domain.place.exception.NotFoundPlaceException;
 import com.server.booyoungee.domain.review.comment.dao.CommentRepository;
 import com.server.booyoungee.domain.review.comment.domain.Comment;
 import com.server.booyoungee.domain.review.stars.domain.Stars;
+import com.server.booyoungee.global.common.PageableResponse;
 import com.server.booyoungee.global.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
@@ -75,7 +78,7 @@ public class TourPlaceService {
 	}
 
 	@Transactional
-	public PlaceSummaryListResponse getPlaceByKeyword(List<TourInfoCommonResponse> dto) {
+	public PlaceSummaryPageResponse getPlaceByKeyword(List<TourInfoCommonResponse> dto, PageRequest request) {
 		List<PlaceSummaryResponse> tourPlaces = new ArrayList<>();
 		for (TourInfoCommonResponse response : dto) {
 			Optional<TourPlace> tourPlace = tourPlaceRepository.findByContentId(response.contentid());
@@ -95,7 +98,7 @@ public class TourPlaceService {
 					));
 			}
 		}
-		return PlaceSummaryListResponse.of(tourPlaces);
+		return PlaceSummaryPageResponse.of(tourPlaces, PageableResponse.of(request));
 	}
 
 	@Transactional //북마크 조회시 사용

--- a/src/main/java/com/server/booyoungee/domain/place/dto/response/PlaceSummaryPageResponse.java
+++ b/src/main/java/com/server/booyoungee/domain/place/dto/response/PlaceSummaryPageResponse.java
@@ -11,8 +11,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record PlaceSummaryPageResponse<T>(
 
 	@Schema(
-		description = "장소 요약 목록",
-		example = "[{\"id\":1,\"name\":\"임랑해수욕장\",\"basicAddress\":\"부산광역시 기장군 장안읍 임랑해안길 51\",\"stars\":4.7,\"likes\":12,\"reviews\":11,\"movieName\":\"극비 수사\"}]",
+		description = "영화 장소 요약 목록",
+		example = "[{\"id\":1,\"name\":\"임랑해수욕장\",\"basicAddress\":\"부산광역시 기장군 장안읍 임랑해안길 51\",\"mapX\":\"129.244\",\"mapY\":\"35.244\",\"stars\":4.7,\"likes\":12,\"reviews\":11,\"movieName\":\"극비 수사\",\"type\":\"MOVIE\",\"images\":[\"https://booyoungee.s3.ap-northeast-2.amazonaws.com/임랑해수욕장1.jpg\",\"https://booyoungee.s3.ap-northeast-2.amazonaws.com/임랑해수욕장2.jpg\"]}]",
 		requiredMode = REQUIRED
 	)
 	List<PlaceSummaryResponse> contents,

--- a/src/main/java/com/server/booyoungee/global/common/PageableResponse.java
+++ b/src/main/java/com/server/booyoungee/global/common/PageableResponse.java
@@ -58,4 +58,14 @@ public record PageableResponse<T>(
 			.isEnd(isEnd)
 			.build();
 	}
+
+	public static <T> PageableResponse<T> of(Pageable pageable) {
+		return PageableResponse.<T>builder()
+			.page(pageable.getPageNumber())
+			.size(pageable.getPageSize())
+			.totalPages(0)
+			.totalElements(0L)
+			.isEnd(false)
+			.build();
+	}
 }


### PR DESCRIPTION
### #[TC-94]-api/v1/tourInfoOpenApi/keyword 페이징 처리 적용

## *⛳️ Work Description*

- 프론트에 요청에 따라 api/v1/tourInfoOpenApi/keyword API에 페이징 처리를 적용하였습니다.


## *📸 Screenshot*

<img width="1400" alt="스크린샷 2024-09-27 오후 5 25 51" src="https://github.com/user-attachments/assets/3d2b672c-379e-4e9d-ae56-c6532892cfd9">


*📢 To Reviewers*
- OpenApi 특성 상 totalElements를 파악하기 어려워 해당 관련 필드는 0 처리 했습니다.